### PR TITLE
style: Change title color to neon green for readability

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -16,12 +16,15 @@ body{
 }
 .container{max-width:1100px;margin:0 auto}
 header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:18px}
+header h1, .left h2, .right h2, .card h3 {
+  color: #39FF14; /* Neon Green */
+}
 header h1{margin:0}
 form#monthForm{display:flex;align-items:center;gap:8px}
 .csv{margin-left:8px;padding:6px 10px;background:#111827;color:#fff;border-radius:6px;text-decoration:none}
 .summary{display:flex;gap:12px;margin-bottom:18px}
 .card{background:var(--card);padding:12px;border-radius:8px;flex:1;box-shadow:0 1px 3px rgba(0,0,0,0.06)}
-.card h3{margin:0 0 6px 0;color:var(--muted)}
+.card h3{margin:0 0 6px 0}
 .amount{font-size:1.4rem;font-weight:700}
 .amount.positive{color:var(--success)}
 .amount.negative{color:var(--danger)}


### PR DESCRIPTION
This commit addresses a readability issue where the black titles were difficult to see against the new high-tech background. The CSS has been updated to change the color of all `h1`, `h2`, and `h3` elements to neon green, making them stand out and improving the overall user experience.