### PR TITLE
style: Ensure all titles are neon green

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -16,7 +16,7 @@ body{
 }
 .container{max-width:1100px;margin:0 auto}
 header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:18px}
-header h1, .left h2, .right h2, .card h3 {
+h1, h2, h3 {
   color: #39FF14; /* Neon Green */
 }
 header h1{margin:0}


### PR DESCRIPTION
This commit corrects an oversight where not all titles were being colored correctly. A more general CSS rule has been applied to target all `h1`, `h2`, and `h3` elements, ensuring that every title in the application is now neon green for better readability.